### PR TITLE
Handle lxml exception when parsing Netconf response.

### DIFF
--- a/netconf_client/session.py
+++ b/netconf_client/session.py
@@ -108,11 +108,11 @@ class Session:
         while True:
             try:
                 msg = self.parser.send(self.mode)
+                ele = etree.fromstring(msg)
             except Exception as e:
                 logger.info("Stopping recv thread due to exception %s", str(e))
                 return
 
-            ele = etree.fromstring(msg)
             if ele.xpath("/nc:rpc-reply", namespaces=NAMESPACES):
                 try:
                     f = self.rpc_reply_futures.get(block=False)


### PR DESCRIPTION
Due to a mistake on Netconf server side a malformed RPC reply is received at netconf_client
leading to an exception when parsing the response (lxml.etree.fromstring) in the receive loop.
Unfortunately, the traceback (see below, please) is shown in CLI output and the CLI command times out.
With the moved source code line at least the output should no longer appear.
Nevertheless, the command will still run into timeout.
A better approach would be to set the future's exception. But, I don't know what I should pass to the RpcError constructor.

`
Exception in thread Thread-15 (_recv_loop):
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/site-packages/netconf_client/session.py", line 115, in _recv_loop
    ele = etree.fromstring(msg)
  File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1896, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1784, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1141, in lxml.etree._BaseParser._parseDoc
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
  File "<string>", line 1
lxml.etree.XMLSyntaxError: PCDATA invalid Char value 22, line 1, column 338
`
