### PR TITLE
fix: double read from future while getting NC server response

### DIFF
--- a/netconf_client/ncclient.py
+++ b/netconf_client/ncclient.py
@@ -222,7 +222,7 @@ class Manager:
                     if not r:
                         self._log_rpc_failure("RPC returned without result")
                     else:
-                        (raw, ele) = f.result(timeout=timeout)
+                        (raw, ele) = r
                         self._log_rpc_response(raw)
                     return (raw, ele)
                 except TimeoutError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netconf_client"
-version = "2.0.0"
+version = "2.0.1"
 description = "A Python NETCONF client"
 authors = ["ADTRAN, Inc."]
 license = "Apache-2.0"


### PR DESCRIPTION
Small buf fix: double read from future while getting NC server response.