### PR TITLE
Implement <cancel-commit> operation

### DIFF
--- a/netconf_client/ncclient.py
+++ b/netconf_client/ncclient.py
@@ -4,6 +4,7 @@ import logging
 import inspect
 from concurrent.futures import CancelledError, TimeoutError
 from queue import Empty
+from typing import Optional
 import time
 
 from lxml import etree
@@ -16,6 +17,7 @@ from netconf_client.rpc import (
     copy_config,
     discard_changes,
     commit,
+    cancel_commit,
     lock,
     unlock,
     kill_session,
@@ -371,6 +373,15 @@ class Manager:
             persist_id=persist_id,
         )
         self._send_rpc(rpc_xml)
+
+    def cancel_commit(self, persist_id: Optional[str] = None):
+        """Send a ``<cancel-commit>`` request
+
+        :param str persist_id: A persistent confirmed commit id given in the ``<commit>``
+                               request. Can be None (default), if ``<cancel-commit>`` is issued
+                               on the same session that issued the confirmed commit.
+        """
+        self._send_rpc(cancel_commit(persist_id))
 
     def lock(self, target):
         """Send a ``<lock>`` request

--- a/netconf_client/rpc.py
+++ b/netconf_client/rpc.py
@@ -1,4 +1,6 @@
 import uuid
+from typing import Optional
+
 from lxml import etree
 
 
@@ -93,6 +95,17 @@ def commit(
     if persist_id:
         pieces.append("<persist-id>{}</persist-id>".format(persist_id))
     pieces.append("</commit>")
+    return make_rpc("".join(pieces), msg_id=msg_id)
+
+
+def cancel_commit(persist_id: Optional[str] = None, msg_id=None):
+    pieces = []
+    pieces.append("<cancel-commit>")
+
+    if persist_id:
+        pieces.append(f"<persist-id>{persist_id}</persist-id>")
+
+    pieces.append("</cancel-commit>")
     return make_rpc("".join(pieces), msg_id=msg_id)
 
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -416,6 +416,49 @@ def test_commit(session, fake_id):
         )
 
 
+def test_cancel_commit_default_0(session, fake_id):
+    session.replies.append(None)
+    with Manager(session, timeout=1) as mgr:
+        mgr.cancel_commit()
+        assert session.sent[0] == uglify(
+            """
+            <rpc message-id="fake-id" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+              <cancel-commit>
+              </cancel-commit>
+            </rpc>
+            """
+        )
+
+
+def test_cancel_commit_default_1(session, fake_id):
+    session.replies.append(None)
+    with Manager(session, timeout=1) as mgr:
+        mgr.cancel_commit(persist_id="")
+        assert session.sent[0] == uglify(
+            """
+            <rpc message-id="fake-id" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+              <cancel-commit>
+              </cancel-commit>
+            </rpc>
+            """
+        )
+
+
+def test_cancel_commit_persist_id(session, fake_id):
+    session.replies.append(None)
+    with Manager(session, timeout=1) as mgr:
+        mgr.cancel_commit(persist_id="IQ,d4668")
+        assert session.sent[0] == uglify(
+            """
+            <rpc message-id="fake-id" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+              <cancel-commit>
+                <persist-id>IQ,d4668</persist-id>
+              </cancel-commit>
+            </rpc>
+            """
+        )
+
+
 def test_lock(session, fake_id):
     session.replies.append(None)
     with Manager(session, timeout=1) as mgr:


### PR DESCRIPTION
`<cancel-commit>` is a part of Confirmed Commit Capability, however it wasn't implemented before.