### PR TITLE
Close bundle if an exception occurs during session init.

### DIFF
--- a/netconf_client/connect.py
+++ b/netconf_client/connect.py
@@ -75,7 +75,12 @@ def connect_ssh(
         transport.close()
         raise
     bundle = SshSessionSock(sock, transport, channel)
-    return Session(bundle)
+    try:
+        session = Session(bundle)
+    except Exception:
+        bundle.close()
+        raise
+    return session
 
 
 def connect_tls(


### PR DESCRIPTION
Close the SsHSessionSock bundle if an error occurs during session creation.

Fixes: https://github.com/ADTRAN/netconf_client/issues/38