### PR TITLE
Adds a timeout to the SSH channel.

### DIFF
--- a/netconf_client/connect.py
+++ b/netconf_client/connect.py
@@ -60,7 +60,7 @@ def connect_ssh(
     hostkey = _try_load_hostkey_b64(hostkey_b64) if hostkey_b64 else None
     transport.connect(username=username, password=password, pkey=pkey)
     try:
-        channel = transport.open_session()
+        channel = transport.open_session(timeout=general_timeout)
     except Exception:
         transport.close()
         raise
@@ -177,7 +177,8 @@ class CallhomeManager:
         self.server_socket.settimeout(timeout)
         (sock, remote_host) = self.server_socket.accept()
         self.server_socket.settimeout(None)
-        logger.info("Callhome connection initiated from remote host %s", remote_host)
+        logger.info(
+            "Callhome connection initiated from remote host %s", remote_host)
         return sock
 
     def accept_one_ssh(self, *args, **kwds):

--- a/netconf_client/connect.py
+++ b/netconf_client/connect.py
@@ -177,8 +177,7 @@ class CallhomeManager:
         self.server_socket.settimeout(timeout)
         (sock, remote_host) = self.server_socket.accept()
         self.server_socket.settimeout(None)
-        logger.info(
-            "Callhome connection initiated from remote host %s", remote_host)
+        logger.info("Callhome connection initiated from remote host %s", remote_host)
         return sock
 
     def accept_one_ssh(self, *args, **kwds):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netconf_client"
-version = "3.1.1"
+version = "3.1.2"
 description = "A Python NETCONF client"
 authors = ["ADTRAN, Inc."]
 license = "Apache-2.0"


### PR DESCRIPTION
This resolves an issue in which a `channel.recv()` operation can hang when the host's `sshd` is alive but `netconfd` has hung or fallen over.  The TCP socket and Paramiko Transport do not time out because data is still flowing, but the NETCONF connection hangs.  We have observed a simple NETCONF HELLO exchange to hang for over 2.5 hours in the wild despite the socket timeout being set.

Paramiko channels, it turns out, have their own timeout that is independent of the socket/transport timeout.  So when we call `sock.recv(1024)` in `parse_messages()`, `sock` is not a `socket.Socket` as one might suppose, nor is it governed by the timeouts set in `connect_ssh()`.

### Cross-references:
[Paramiko docs](https://docs.paramiko.org/en/latest/api/channel.html)
[Paramiko source](https://github.com/paramiko/paramiko/blob/23f92003898b060df0e2b8b1d889455264e63a3e/paramiko/channel.py#L75)
[Related issue](https://github.com/ADTRAN/netconf_client/issues/28)

(Turns out I considered doing this in #28 but it didn't fix what I was chasing at the time).