### PR TITLE
More Fun with Timeouts

### DIFF
--- a/netconf_client/connect.py
+++ b/netconf_client/connect.py
@@ -60,6 +60,8 @@ def connect_ssh(
     hostkey = _try_load_hostkey_b64(hostkey_b64) if hostkey_b64 else None
     transport.connect(username=username, password=password, pkey=pkey)
     try:
+        #  Paramiko always opens the channel in blocking mode, even when a timeout is specified.  See https://github.com/paramiko/paramiko/blob/23f92003898b060df0e2b8b1d889455264e63a3e/paramiko/channel.py#L612-L633
+        #  This means that even if the Transport is holding a non-blocking socket, and the channel is created with a timeout, a channel.read() call can still hang if the remote misbehaves.
         channel = transport.open_session(timeout=initial_timeout)
         channel.settimeout(general_timeout)
     except Exception:

--- a/netconf_client/connect.py
+++ b/netconf_client/connect.py
@@ -60,7 +60,8 @@ def connect_ssh(
     hostkey = _try_load_hostkey_b64(hostkey_b64) if hostkey_b64 else None
     transport.connect(username=username, password=password, pkey=pkey)
     try:
-        channel = transport.open_session(timeout=general_timeout)
+        channel = transport.open_session(timeout=initial_timeout)
+        channel.settimeout(general_timeout)
     except Exception:
         transport.close()
         raise


### PR DESCRIPTION
In https://github.com/ADTRAN/netconf_client/pull/45, I erroneously believed that a call to Paramiko's `Transport.open_channel()` with the `timeout` kwarg would set a timeout on the resulting Paramiko channel object.  As discussed at https://github.com/ADTRAN/netconf_client/issues/28#issuecomment-2515438889, that timeout only pertains to _opening_ the channel.  There is a separate instance method to set the timeout for subsequent channel IO, which is implemented here.

Given this updated understanding of the timeout parameter in `open_channel()`, I have changed that timeout from `general_timeout` to `initial_timeout`.  I am not attached to this decision if others disagree.  I also added a detailed comment with link to the relevant Paramiko code, so that anybody subsequently reading this code may better understand what it is doing and why.

Closes https://github.com/ADTRAN/netconf_client/issues/28

Builds on https://github.com/ADTRAN/netconf_client/pull/45