### PR TITLE
add: specific timeout to Netconf client RPCs

### DIFF
--- a/netconf_client/ncclient.py
+++ b/netconf_client/ncclient.py
@@ -85,7 +85,15 @@ class Manager:
     @staticmethod
     def _timeout_from_arg(timeout, default):
         return (
-            timeout if isinstance(timeout, (int, float, )) and timeout >= 1 
+            timeout
+            if isinstance(
+                timeout,
+                (
+                    int,
+                    float,
+                ),
+            )
+            and timeout >= 1
             else default
         )
 
@@ -118,11 +126,11 @@ class Manager:
 
     def set_rpc_timeout(self, timeout=DEFAULT_RPC_TIMEOUT):
         """
-            Sets a new RPC timeout value or restores the default.
+        Sets a new RPC timeout value or restores the default.
 
-            :param float,int timeout: Duration in seconds to wait for replies (greater zero)
+        :param float,int timeout: Duration in seconds to wait for replies (greater zero)
 
-            If an invalid value is passed, the default value DEFAULT_RPC_TIMEOUT is set. 
+        If an invalid value is passed, the default value DEFAULT_RPC_TIMEOUT is set.
         """
         self.timeout = Manager._timeout_from_arg(timeout, Manager.DEFAULT_RPC_TIMEOUT)
 
@@ -229,7 +237,7 @@ class Manager:
         after they have been logged.
 
         :param str rpc_xml: XML RPC message to sent to NC server
-        
+
         :param timeout (optional): Applies a specific timeout value for this _send_rpc() call.
                If given, this timeout is used instead of the set timeout
                (see __init__() and set_rpc_timeout()).
@@ -331,7 +339,9 @@ class Manager:
         (raw, ele) = self._send_rpc(rpc_xml, timeout)
         return DataReply(raw, ele)
 
-    def get_config(self, source="running", filter=None, with_defaults=None, timeout=None):
+    def get_config(
+        self, source="running", filter=None, with_defaults=None, timeout=None
+    ):
         """Send a ``<get-config>`` request
 
         :param str source: The datastore to retrieve the configuration from
@@ -448,7 +458,12 @@ class Manager:
         self._send_rpc(discard_changes(), timeout)
 
     def commit(
-        self, confirmed=False, confirm_timeout=None, persist=None, persist_id=None, timeout=None
+        self,
+        confirmed=False,
+        confirm_timeout=None,
+        persist=None,
+        persist_id=None,
+        timeout=None,
     ):
         """Send a ``<commit>`` request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netconf_client"
-version = "3.1.3"
+version = "3.2.0.1"
 description = "A Python NETCONF client"
 authors = ["ADTRAN, Inc."]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netconf_client"
-version = "3.2.0.1"
+version = "3.2.0"
 description = "A Python NETCONF client"
 authors = ["ADTRAN, Inc."]
 license = "Apache-2.0"

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -99,15 +99,42 @@ class LogSentry:
 @pytest.mark.parametrize(
     "timeout_arg,timeout_set",
     [
-        (None, Manager.DEFAULT_RPC_TIMEOUT, ),
-        (Manager.DEFAULT_RPC_TIMEOUT, Manager.DEFAULT_RPC_TIMEOUT, ),
-        (10, 10, ),
-        (300, 300, ),
-        (47.3, 47.3, ),
-        (0, Manager.DEFAULT_RPC_TIMEOUT, ),
-        (0.5, Manager.DEFAULT_RPC_TIMEOUT, ),
-        (-1, Manager.DEFAULT_RPC_TIMEOUT, ),
-        ("200", Manager.DEFAULT_RPC_TIMEOUT, ),
+        (
+            None,
+            Manager.DEFAULT_RPC_TIMEOUT,
+        ),
+        (
+            Manager.DEFAULT_RPC_TIMEOUT,
+            Manager.DEFAULT_RPC_TIMEOUT,
+        ),
+        (
+            10,
+            10,
+        ),
+        (
+            300,
+            300,
+        ),
+        (
+            47.3,
+            47.3,
+        ),
+        (
+            0,
+            Manager.DEFAULT_RPC_TIMEOUT,
+        ),
+        (
+            0.5,
+            Manager.DEFAULT_RPC_TIMEOUT,
+        ),
+        (
+            -1,
+            Manager.DEFAULT_RPC_TIMEOUT,
+        ),
+        (
+            "200",
+            Manager.DEFAULT_RPC_TIMEOUT,
+        ),
     ],
     ids=[
         "timeout is None, expect default",
@@ -135,6 +162,7 @@ def test_manager_lifecycle(session, timeout_arg, timeout_set):
         assert mgr.log_id is None
         assert mgr.session_id() == 4711
     assert session.closed
+
 
 def test_manager_lifecycle_with_id(session):
     assert Manager.DEFAULT_RPC_TIMEOUT == 120
@@ -779,29 +807,111 @@ def test_dispatch(session, fake_id):
             ],
         )
 
+
 # This test calls all public RPC methods of class Manager with specific (extra) timeout argument
 # and checks whether that timeout is passed to internal Manager._send_rpc method.
 @pytest.mark.parametrize(
     "rpc, kwargs, retval, timeout",
     [
-        (Manager.edit_config, {'config': '<anything/>', }, None, 1, ),
-        (Manager.get, {}, (RPC_REPLY_DATA, etree.fromstring(RPC_REPLY_DATA)), 2, ),
-        (Manager.get_config, {}, (RPC_REPLY_DATA, etree.fromstring(RPC_REPLY_DATA)), 3, ),
-        (Manager.get_data, {}, (RPC_REPLY_DATA, etree.fromstring(RPC_REPLY_DATA)), 4, ),
-        (Manager.copy_config, {'target': 'running', 'source': 'startup', }, None, 5, ),
-        (Manager.discard_changes, {}, None, 6, ),
-        (Manager.commit, {}, None, 7, ),
-        (Manager.cancel_commit, {}, None, 8, ),
-        (Manager.lock, {'target': 'running', }, None, 9, ),
-        (Manager.unlock, {'target': 'running', }, None, 10, ),
-        (Manager.kill_session, {'session_id': 4712}, None, 11, ),
-        (Manager.close_session, {}, None, 12, ),
-        (Manager.create_subscription, {}, None, 13, ),
-        (Manager.validate, {'source': 'running', }, None, 14, ),
+        (
+            Manager.edit_config,
+            {
+                "config": "<anything/>",
+            },
+            None,
+            1,
+        ),
+        (
+            Manager.get,
+            {},
+            (RPC_REPLY_DATA, etree.fromstring(RPC_REPLY_DATA)),
+            2,
+        ),
+        (
+            Manager.get_config,
+            {},
+            (RPC_REPLY_DATA, etree.fromstring(RPC_REPLY_DATA)),
+            3,
+        ),
+        (
+            Manager.get_data,
+            {},
+            (RPC_REPLY_DATA, etree.fromstring(RPC_REPLY_DATA)),
+            4,
+        ),
+        (
+            Manager.copy_config,
+            {
+                "target": "running",
+                "source": "startup",
+            },
+            None,
+            5,
+        ),
+        (
+            Manager.discard_changes,
+            {},
+            None,
+            6,
+        ),
+        (
+            Manager.commit,
+            {},
+            None,
+            7,
+        ),
+        (
+            Manager.cancel_commit,
+            {},
+            None,
+            8,
+        ),
+        (
+            Manager.lock,
+            {
+                "target": "running",
+            },
+            None,
+            9,
+        ),
+        (
+            Manager.unlock,
+            {
+                "target": "running",
+            },
+            None,
+            10,
+        ),
+        (
+            Manager.kill_session,
+            {"session_id": 4712},
+            None,
+            11,
+        ),
+        (
+            Manager.close_session,
+            {},
+            None,
+            12,
+        ),
+        (
+            Manager.create_subscription,
+            {},
+            None,
+            13,
+        ),
+        (
+            Manager.validate,
+            {
+                "source": "running",
+            },
+            None,
+            14,
+        ),
     ],
 )
 def test_rpc_with_specific_timeout(session, rpc, kwargs, retval, timeout):
-    with patch.object(target=Manager, attribute='_send_rpc', return_value=retval) as p:
+    with patch.object(target=Manager, attribute="_send_rpc", return_value=retval) as p:
         with Manager(session) as mgr:
             # invoke without extra timeout parameter (use the default = None)
             rpc(mgr, **kwargs)
@@ -810,7 +920,13 @@ def test_rpc_with_specific_timeout(session, rpc, kwargs, retval, timeout):
             assert mock_args[0][0][1] is None
 
             # invoke again with timeout parameter
-            rpc(mgr, **{**kwargs, 'timeout': timeout, })
+            rpc(
+                mgr,
+                **{
+                    **kwargs,
+                    "timeout": timeout,
+                }
+            )
             assert p.call_count == 2
             mock_args = p.call_args_list
             assert mock_args[1][0][1] == timeout


### PR DESCRIPTION
All public RPC functions of class Manager now have a new timeout default parameter. If not given (or set to None), the Manager's timeout value is used as before.
If given, the specific timeout is used for this one RPC, the original timeout value stored in the Manager is not changed.

Moreover, the timeout value given once at construction of the Manager object can now be changed at runtime.