### PR TITLE
feat: Allow paramiko 4.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -870,13 +870,13 @@ files = [
 
 [[package]]
 name = "paramiko"
-version = "3.4.0"
+version = "3.5.1"
 description = "SSH2 protocol library"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "paramiko-3.4.0-py3-none-any.whl", hash = "sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7"},
-    {file = "paramiko-3.4.0.tar.gz", hash = "sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3"},
+    {file = "paramiko-3.5.1-py3-none-any.whl", hash = "sha256:43b9a0501fc2b5e70680388d9346cf252cfb7d00b0667c39e80eb43a408b8f61"},
+    {file = "paramiko-3.5.1.tar.gz", hash = "sha256:b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822"},
 ]
 
 [package.dependencies]
@@ -1446,4 +1446,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "cd3b8bb14038ed76ecda3ea38d300adc42d3643d9cd3b45426885df60615b1c9"
+content-hash = "812565ee05438cc44408899e9b216897fa9850afa2312ffa6e467e5324b7fd21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netconf_client"
-version = "3.3.0"
+version = "3.4.0"
 description = "A Python NETCONF client"
 authors = ["ADTRAN, Inc."]
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 lxml = "^4.6.3 || ^5 || ^6"
-paramiko = "^2.7.2 || ^3"
+paramiko = "^2.7.2 || ^3 || ^4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
Widen the range of allowed paramiko versions to include 4.x now that paramiko 4.0.0 has been released.

Paramiko release notes: https://www.paramiko.org/changelog.html

paramiko 4.x drops support for python 3.8, which is why the lock file only updated to 3.5.1 and not 4.0.0.

To check that paramiko 4.x should work fine, I made local changes to use python 3.10 and python 3.12 + paramiko 4.0.0 and ran the CI checks and all tests pass.