### PR TITLE
feat: Allow paramiko 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netconf_client"
-version = "3.5.0"
+version = "3.6.0"
 description = "A Python NETCONF client"
 authors = ["ADTRAN, Inc."]
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 lxml = "^4.6.3 || ^5 || ^6"
-paramiko = "^2.7.2 || ^3 || ^4"
+paramiko = "^2.7.2 || ^3 || ^4 || ^5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
Release notes:
https://www.paramiko.org/changelog.html

I manually verified the CI checks pass with python 3.10 + paramiko 5 and python 3.12 + paramiko 5. (The old python 3.8 is no longer supported beginning in paramiko 4.)